### PR TITLE
Add header.regsub().

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -126,6 +126,7 @@ VMOD_TESTS = \
 	tests/header/keep-others.vtc \
 	tests/header/remove.vtc \
 	tests/header/some-data.vtc \
+	tests/header/regsub.vtc \
 	tests/saintmode/test01.vtc \
 	tests/saintmode/test02.vtc \
 	tests/saintmode/test03.vtc \

--- a/src/tests/header/regsub.vtc
+++ b/src/tests/header/regsub.vtc
@@ -1,0 +1,114 @@
+varnishtest "Header-vmod: Test substitution"
+
+server s1 {
+	loop 2 {
+		rxreq
+		expect req.http.Pebbles == "quuxquux"
+		expect req.http.Y-Prefix-Foo == "foo"
+		expect req.http.X-Prefix-Foo == <undef>
+		txresp -hdr "Foo: barf" -hdr "v1: val=foo" -hdr "v2: VAL=bar"
+	}
+} -start
+
+varnish v1 -vcl+backend {
+	import header from "${vmod_builddir}/.libs/libvmod_header.so";
+
+	sub vcl_recv {
+		header.regsub(req, "bam", "quux", all=true);
+		return (pass);
+	}
+
+	sub vcl_backend_fetch {
+		header.regsub(bereq, "^(?i)X-Prefix", "Y-Prefix");
+	}
+
+	sub vcl_backend_response {
+		header.regsub(beresp, "^Foo: (b)(a)(r)(f)", "Bar: \4\3\2p");
+	}
+
+	sub vcl_deliver {
+		header.regsub(resp, "^(?i)V(\d): (?-i)val=(.*)$", "Val\1: \2");
+	}
+} -start
+
+client c1 {
+	# Run twice to test the cached compiled regexen in PRIV_CALL scope
+	loop 2 {
+		txreq -hdr "x-prefix-foo: foo" -hdr "Pebbles: bambam"
+		rxresp
+		expect resp.status == 200
+		expect resp.http.Bar == "frap"
+		expect resp.http.Foo == <undef>
+		expect resp.http.Val1 == "foo"
+		expect resp.http.V2 == "VAL=bar"
+		expect resp.http.Val2 == <undef>
+	}
+} -run
+
+logexpect l1 -v v1 -d 1 -g vxid -q {Begin ~ "^bereq"} {
+ 	expect 0 * Begin bereq
+ 	expect * = BereqUnset   "^x-prefix-foo: foo$"
+ 	expect 0 = BereqHeader  "^Y-Prefix-foo: foo$"
+ 	expect * = BerespUnset  "^Foo: barf$"
+ 	expect 0 = BerespHeader "^Bar: frap$"
+ 	expect * = End
+} -run
+
+logexpect l1 -v v1 -d 1 -g vxid -q {Begin ~ "^req"} {
+ 	expect 0 * Begin req
+ 	expect * = ReqUnset   "^Pebbles: bambam$"
+ 	expect 0 = ReqHeader  "^Pebbles: quuxquux$"
+ 	expect * = RespUnset  "^v1: val=foo"
+ 	expect 0 = RespHeader "^Val1: foo$"
+ 	expect * = End
+} -run
+
+## Errors
+
+varnish v1 -vcl {
+	import header from "${vmod_builddir}/.libs/libvmod_header.so";
+	backend b { .host="${bad_ip}"; }
+
+	sub vcl_recv {
+		header.regsub(req, req.http.No-Such-Header, "a");
+	}
+}
+
+logexpect l1 -v v1 -d 0 -g vxid {
+ 	expect 0 * Begin req
+ 	expect * = VCL_Error {^header\.regsub\(\): regex is NULL$}
+ 	expect * = End
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 503
+	expect resp.reason == "VCL failed"
+} -run
+
+logexpect l1 -wait
+
+varnish v1 -vcl {
+	import header from "${vmod_builddir}/.libs/libvmod_header.so";
+	backend b { .host="${bad_ip}"; }
+
+	sub vcl_recv {
+		header.regsub(req, "(", "a");
+	}
+}
+
+logexpect l1 -v v1 -d 0 -g vxid {
+ 	expect 0 * Begin req
+ 	expect * = VCL_Error {^header\.regsub\(\): cannot compile '\('}
+ 	expect * = End
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 503
+	expect resp.reason == "VCL failed"
+} -run
+
+logexpect l1 -wait

--- a/src/vmod_header.vcc
+++ b/src/vmod_header.vcc
@@ -62,7 +62,45 @@ Example
     ::
     header.remove(beresp.http.set-cookie,"^(?!(funcookie=))");
 
+$Function VOID regsub(PRIV_CALL, HTTP, STRING regex, STRING sub, BOOL all=0)
 
+Description
+        For every header line in the HTTP object, which can be one of
+        ``req``, ``resp``, ``bereq`` or ``beresp``, if the line
+        matches the regular expression ``regex``, then replace it with
+        the result of a substitution using the string ``sub``. ``sub``
+        may include backreferences of the form ``\1`` through ``\9``,
+        which refer to capturing expressions in the ``regex``, or
+        ``\0`` to refer to the entire matched portion of the header
+        line.
+
+        If ``all`` is ``false``, replace the first matched portion of
+        the header line with ``sub``. This is the same operation
+        performed by the VCL native function ``regsub()``. ``all`` is
+        ``false`` by default.
+
+        If ``all`` is ``true``, replace each non-overlapping matched
+        portion of the header line with ``sub``. This is the same
+        operation performed by native ``regsuball()``.
+
+        Note that unlike the other functions in this VMOD,
+        ``regsub()`` applies to the *entire* header line, including
+        the header name, colon separator, and header value. Take care
+        that your substitutions result in valid headers, since
+        ill-formed headers can interfere with the HTTP protocol.
+
+        Consider case sensitivity in the regex match. The standard
+        dictates that header names are case insensitive, but header
+        values are not. The VMOD function does not take care of that
+        for you, but you can express it in the ``regex`` using the
+        ``(?i)`` flag, as shown in the example below (use ``(?-i)`` to
+        turn it off).
+
+        Consider using the ``^`` starting anchor in ``regex`` to be
+        sure to match a header name (and not the same string somewhere
+        in the middle of the line).
+Example
+    :: header.regsub(req, "^(?i)Foo(\\d): (?-i)bar=(.*)$", "Bar\\1: \\2")
 
 ACKNOWLEDGEMENTS
 ================


### PR DESCRIPTION
From the docs:
```
$Function VOID regsub(PRIV_CALL, HTTP, STRING regex, STRING sub, BOOL all=0)
```
For every header line in the HTTP object, which can be one of ``req``, ``resp``, ``bereq`` or ``beresp``, if the line matches the regular expression ``regex``, then replace it with the result of a substitution using the string ``sub``. ``sub`` may include backreferences of the form ``\1`` through ``\9``, which refer to capturing expressions in the ``regex``, or ``\0`` to refer to the entire matched portion of the header line.

 If ``all`` is ``false``, replace the first matched portion of the header line with ``sub``. This is the same operation performed by the VCL native function ``regsub()``. ``all`` is ``false`` by default.

If ``all`` is ``true``, replace each non-overlapping matched portion of the header line with ``sub``. This is the same operation performed by native ``regsuball()``.

Example:
```
header.regsub(req, "^(?i)Foo(\d): (?-i)bar=(.*)$", "Bar\1: \2")
```
Note that unlike the other functions in VMOD header, ``regsub()`` applies to the *entire* header line, including the header name, colon separator, and header value.