### PR TITLE
Fix logic bug when scanning for xkey tokens (6.0 branch)

### DIFF
--- a/src/tests/xkey/test09.vtc
+++ b/src/tests/xkey/test09.vtc
@@ -4,6 +4,9 @@ varnishtest "Test xkey vmod multiple keys, comma separated"
 server s1 {
 	rxreq
 	txresp -hdr "xkey: asdf, fdsa"
+
+	rxreq
+	txresp -hdr "xkey: qwer, rewq"
 } -start
 
 varnish v1 -vcl+backend {
@@ -33,13 +36,26 @@ varnish v1 -vcl+backend {
 client c1 {
 	txreq
 	rxresp
+	txreq -url /2
+	rxresp
 } -run
 
-varnish v1 -expect n_object == 1
+varnish v1 -expect n_object == 2
 
 client c1 {
 	# Test the purge using the asdf key, so we check that we didn't include the comma
 	txreq -hdr "xkey-purge: asdf"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.reason == "Purged"
+} -run
+
+delay 1
+
+varnish v1 -expect n_object == 1
+
+client c1 {
+	txreq -hdr "xkey-purge: rewq"
 	rxresp
 	expect resp.status == 200
 	expect resp.http.reason == "Purged"

--- a/src/vmod_xkey.c
+++ b/src/vmod_xkey.c
@@ -410,7 +410,7 @@ xkey_tok(const char **b, const char **e)
 	t = *b;
 	AN(t);
 
-	while (*t != ',' && isblank(*t))
+	while (*t == ',' || isblank(*t))
 		t++;
 	*b = t;
 


### PR DESCRIPTION
Cherry picked from commit 8e2a912040d3287b531f4698b0c39079184b1e5d

Author: Wesley Spikes <wspikes@squarespace.com>
Date: 22 October 2018 at 04:58:01 CEST
Committer: guillaume quintard <gquintard@users.noreply.github.com>
Commit Date: 22 October 2018 at 20:00:52 CEST

This commit is already present in the `master` and `6.2` branches, but not in the `6.0` one. This commit fix a bug in a new feature for vmod-xkey (Allow comma between keys).
